### PR TITLE
Fix build, sync and cleanup the manpage

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,7 +4,7 @@ SET(OUT_MANPAGE tasknc.1)
 ADD_CUSTOM_COMMAND(
   TARGET ManPages 
   SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/${IN_POD}
-  COMMAND pod2man ARGS -s 1 --section=1 --center="tasknc Manual" --name="tasknc" --release="tasknc ${VERSION}" ${CMAKE_CURRENT_SOURCE_DIR}/${IN_POD} 
+  COMMAND pod2man ARGS --errors=none -s 1 --section=1 --center="tasknc Manual" --name="tasknc" --release="tasknc ${VERSION}" ${CMAKE_CURRENT_SOURCE_DIR}/${IN_POD} 
 ${CMAKE_CURRENT_BINARY_DIR}/${OUT_MANPAGE} 
   OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${OUT_MANPAGE}
 )

--- a/doc/manual.pod
+++ b/doc/manual.pod
@@ -131,7 +131,7 @@ open command prompt
 
 =head1 CONFIGURATION
 
-tasknc honors a config file located at 
+tasknc honors a config file located at
 
     $XDG_CONFIG_HOME/tasknc/config
 
@@ -157,7 +157,9 @@ Commands are either supplied at the command prompt or listed in the configuratio
 
 =item
 
-=item B<color> I<object> I<foreground> I<background> I<rule> assign an I<object> to be a color when I<rule> is satisfied.  Only task I<object>s evaluate I<rule>s.  The following objects are available:
+=item B<color> I<object> I<foreground> I<background> I<rule> assign an I<object> to be a color when I<rule> is satisfied.  Only task I<object>s evaluate I<rule>s.
+
+The following objects are available:
 
 =over 4
 
@@ -169,7 +171,11 @@ Commands are either supplied at the command prompt or listed in the configuratio
 
 =back
 
-=item Colors are specified in one of three formats:
+=item
+
+=item
+
+Colors are specified in one of three formats:
 
 =over 4
 
@@ -181,7 +187,11 @@ Commands are either supplied at the command prompt or listed in the configuratio
 
 =back
 
-=item Rules are specified in the following format: ~I<pattern> I<arg>.  Pattern is a single character; if lowercase it indicates a positive match, and if uppercase it indicates a negative match.  Regular expression arguments must be enclosed in single quotes.  The following patterns are available:
+=item
+
+=item Rules are specified in the following format: ~I<pattern> I<arg>.  Pattern is a single character; if lowercase it indicates a positive match, and if uppercase it indicates a negative match.  Regular expression arguments must be enclosed in single quotes.
+
+The following patterns are available:
 
 =over 4
 
@@ -289,7 +299,9 @@ Commands are either supplied at the command prompt or listed in the configuratio
 
 =item
 
-=item B<sort> I<optarg> applies a sort defined by string I<optarg> or prompts user for sort mode with no arg.  The sort string defines the priority of each sort component.  Tasks will first be compared by the first character's order, if they are equal, the next characters sort order will be evaluated.  The default sort order is due, priority, project, uuid (notated drpu).  Capitalized characters indicate invert the sort for that field.  The following characters are valid sorts:
+=item B<sort> I<optarg> applies a sort defined by string I<optarg> or prompts user for sort mode with no arg.  The sort string defines the priority of each sort component.  Tasks will first be compared by the first character's order, if they are equal, the next characters sort order will be evaluated.  The default sort order is due, priority, project, uuid (notated drpu).  Capitalized characters indicate invert the sort for that field.
+
+The following characters are valid sorts:
 
 =over 4
 

--- a/doc/manual.pod
+++ b/doc/manual.pod
@@ -105,7 +105,7 @@ resort list (prompted for sort order)
 
 =item B<y>
 
-synchronize (run task merge and task push)
+synchronize (run task sync)
 
 =item B<q>
 
@@ -331,7 +331,7 @@ The following characters are valid sorts:
 
 =item
 
-=item B<sync> runs 'task merge && task push'.
+=item B<sync> runs 'task sync'.
 
 =item
 

--- a/src/tasklist.c
+++ b/src/tasklist.c
@@ -308,7 +308,7 @@ void key_tasklist_sync() /* {{{ */
 
 	statusbar_message(cfg.statusbar_timeout, "synchronizing tasks...");
 
-	ret = task_interactive_command("yes n | task merge && task push");
+	ret = task_interactive_command("yes n | task sync");
 
 	if (ret==0)
 	{

--- a/src/tasklist.c
+++ b/src/tasklist.c
@@ -475,8 +475,12 @@ void tasklist_window() /* {{{ */
 		/* check for an empty task list */
 		if (head == NULL)
 		{
-			tnc_fprintf(logfp, LOG_ERROR, "it appears that your task list is empty. %s does not yet support empty task lists.", PROGNAME);
-			ncurses_end(-1);
+			if (strcmp(active_filter,"") == 0){
+				tnc_fprintf(logfp, LOG_ERROR, "it appears that your task list is empty. %s does not yet support empty task lists.", PROGNAME);
+				ncurses_end(-1);
+			}
+			active_filter = strdup("");
+			reload = true;
 		}
 
 		/* get the screen size */


### PR DESCRIPTION
By order of commit:
1. The `pod2man` command finishes with an error status because `doc/manual.pod` uses non-standard formatting to force spacing, and this causes `make` to fail. This commit has `pod2man` run with `--errors=none`, which tells it not to produce any errors, and the build now finishes successfully.
2. The commands `task merge` and `task push` are deprecated in the current version of **Taskwarrior (2.3.0)**, and future releases will apparently remove them altogether. This commit replaces those commands with the `task sync` command that replaces them.
3. I noticed a few inconsistencies in the way the man page was formatted and tried to smooth some of them over in this commit.
4. This commit updates the manpage to reflect the change from `task merge && task push` to `task sync`.

Cheers!
