### PR TITLE
Don't die when encountering unknown JSON fields.

### DIFF
--- a/src/tasks.c
+++ b/src/tasks.c
@@ -342,6 +342,10 @@ task *parse_task(char *line) /* {{{ */
 				line++;
 			line++;
 		}
+		else { /* unknown field */			
+			while (*line != ',' && *line != '}') line++;
+		}
+
 		free(field);
 	}
 


### PR DESCRIPTION
This change just adds a little trap clause at the bottom of parse_task to chomp any unrecognized JSON fields.
