### PR TITLE
Just log pod2man errors to stderr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: $(OUT) doc
 
 doc: tasknc.1
 tasknc.1: doc/manual.pod
-		pod2man --section=1 --center="tasknc Manual" --name="tasknc" --release="tasknc ${VERSION}" $< > $@
+		pod2man --errors=stderr --section=1 --center="tasknc Manual" --name="tasknc" --release="tasknc ${VERSION}" $< > $@
 
 install: tasknc tasknc.1
 		install -D -m755 tasknc ${DESTDIR}${PREFIX}/bin/tasknc

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,7 +4,7 @@ SET(OUT_MANPAGE tasknc.1)
 ADD_CUSTOM_COMMAND(
   TARGET ManPages 
   SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/${IN_POD}
-  COMMAND pod2man ARGS -s 1 --section=1 --center="tasknc Manual" --name="tasknc" --release="tasknc ${VERSION}" ${CMAKE_CURRENT_SOURCE_DIR}/${IN_POD} 
+  COMMAND pod2man ARGS --errors=stderr -s 1 --section=1 --center="tasknc Manual" --name="tasknc" --release="tasknc ${VERSION}" ${CMAKE_CURRENT_SOURCE_DIR}/${IN_POD} 
 ${CMAKE_CURRENT_BINARY_DIR}/${OUT_MANPAGE} 
   OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${OUT_MANPAGE}
 )


### PR DESCRIPTION
A simple workaround for the changed support for `=item` with no following text, to prevent warnings from `pod2man` from breaking builds.
