### PR TITLE
Fix add task to get the right task id

### DIFF
--- a/src/tasklist.c
+++ b/src/tasklist.c
@@ -668,7 +668,7 @@ void tasklist_task_add(void) { /* {{{ */
     tnc_fprintf(logfp, LOG_DEBUG, "running: %s", cmd);
     cmdout = popen(cmd, "r");
 
-    while (fgets(line, sizeof(struct line) - 1, cmdout) != NULL) {
+    while (fgets(line, TOTALLENGTH, cmdout) != NULL) {
         if (sscanf(line, "Created task %hu.", &tasknum)) {
             break;
         }


### PR DESCRIPTION
Adding a task would create a new empty task which was then edited with an external editor by getting the task id replied by taskwarrior. Since the maximum length of the string to be read was wrong, ids with more than one digit would cause the task with id of only the first digit to be edited instead. This commit fixes it. Should fix #41 .