### PR TITLE
Suppress confirmation for delete and undo

### DIFF
--- a/src/tasklist.c
+++ b/src/tasklist.c
@@ -58,7 +58,7 @@ void key_tasklist_delete(void) { /* {{{ */
 
     statusbar_message(cfg.statusbar_timeout, "deleting task");
 
-    ret = task_background_command("task %s delete");
+    ret = task_background_command("task rc.confirmation=no %s delete");
     tasklist_remove_task(cur);
 
     tasklist_command_message(ret, "delete failed (%d)", "delete successful");
@@ -361,7 +361,7 @@ void key_tasklist_toggle_started(void) { /* {{{ */
 
 void key_tasklist_undo(void) { /* {{{ */
     /* handle a keyboard direction to run an undo */
-    int ret = task_background_command("task undo");
+    int ret = task_background_command("task rc.confirmation=no undo");
 
     if (ret == 0) {
         statusbar_message(cfg.statusbar_timeout, "undo executed");


### PR DESCRIPTION
Since the delete and undo taskwarrior commands require confirmation by default and these commands are open through a (unidirectional) pipe stream in the background, when executing the undo or delete commands tasknc simply freezes, since the confirmation never happens.
This patch makes so that these commands don't require confirmation.

If there already is a convenient way to open a background process, write its output to the screen (to the pager for example), and then wait for input from the user to then pass it back to the background process, that would probably be better than simply suppressing the confirmation for these two commands. Otherwise, making these functions work without confirmation is at least better than letting the program freeze.
